### PR TITLE
setAuthHeader: accessToken parameter is now object

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,12 +145,12 @@ This method receives two objects as arguments.
          * If `manageAuthHeader` is enabled, `setAuthHeader` receives
          * object with default headers, when access token state changes.
          * @param {Object} headers - reference to axios default request headers object (https://github.com/axios/axios#custom-instance-defaults)
-         * @param {String|null} accessToken
+         * @param {Object|null} accessToken
          */
         setAuthHeader(headers, accessToken) {
             if (accessToken) {
                 // `common` indicates that it's a default header for all HTTP methods
-                headers.common.Authorization = `Bearer ${accessToken}`;
+                headers.common.Authorization = `Bearer ${accessToken.token}`;
             } else {
                 delete headers.common.Authorization;
             }

--- a/src/defaultConfig.js
+++ b/src/defaultConfig.js
@@ -3,7 +3,7 @@ const config = {
 
     setAuthHeader(headers, accessToken) {
         if (accessToken) {
-            headers.common.Authorization = `Bearer ${accessToken}`;
+            headers.common.Authorization = `Bearer ${accessToken.token}`;
         } else {
             delete headers.common.Authorization;
         }


### PR DESCRIPTION
`setAuthHeader` now accepts `accessToken` as an object instead of a `string`.  This change is needed to be able to support dynamic token type. e.g.:
```js
      setAuthHeader(headers, accessToken) {
            if (accessToken) {
                headers.common.Authorization = `${accessToken.tokenType} ${accessToken.token}`;
            } else {
                delete headers.common.Authorization;
            }
        },
```